### PR TITLE
Added option to search for the word which is being looked up in the buffer.

### DIFF
--- a/doc/viewdoc.txt
+++ b/doc/viewdoc.txt
@@ -303,6 +303,12 @@ g:viewdoc_dontswitch	=0 (default)		*g:viewdoc_dontswitch*
 	|viewdoc-windowed| or |viewdoc-tabbed| configurations and probably
 	very bad idea in all other cases.
 
+g:viewdoc_copy_to_search_reg	=0 (default)		*g:viewdoc_copy_to_search_reg*
+				=1
+	If set to 1, the word which is looked up is also copied into the Vims
+	search register which allows to easily search in the documentation for
+	occurrences of this word.
+
 Added by man handler:~
 
 g:viewdoc_man_cmd   ="/usr/bin/man" (default)   *g:viewdoc_man_cmd*

--- a/plugin/viewdoc.vim
+++ b/plugin/viewdoc.vim
@@ -30,6 +30,9 @@ endif
 if !exists('g:viewdoc_dontswitch')
 	let g:viewdoc_dontswitch=0
 endif
+if !exists('g:viewdoc_copy_to_search_reg')
+	let g:viewdoc_copy_to_search_reg=0
+endif
 
 """ Interface
 " - command
@@ -42,9 +45,15 @@ if !exists('g:no_plugin_abbrev') && !exists('g:no_viewdoc_abbrev')
 endif
 " - map
 if !exists('g:no_plugin_maps') && !exists('g:no_viewdoc_maps')
-	inoremap <unique> <F1>  <C-O>:call ViewDoc('new', '<cword>')<CR>
-	nnoremap <unique> <F1>  :call ViewDoc('new', '<cword>')<CR>
-	nnoremap <unique> K     :call ViewDoc('doc', '<cword>')<CR>
+	if g:viewdoc_copy_to_search_reg
+		inoremap <unique> <F1>  <C-O>:let @/ = '\<'.expand('<cword>').'\>'<CR><C-O>:call ViewDoc('new', '<cword>')<CR>
+		nnoremap <unique> <F1>  :let @/ = '\<'.expand('<cword>').'\>'<CR>:call ViewDoc('new', '<cword>')<CR>
+		nnoremap <unique> K     :let @/ = '\<'.expand('<cword>').'\>'<CR>:call ViewDoc('doc', '<cword>')<CR>
+	else
+		inoremap <unique> <F1>  <C-O>:call ViewDoc('new', '<cword>')<CR>
+		nnoremap <unique> <F1>  :call ViewDoc('new', '<cword>')<CR>
+		nnoremap <unique> K     :call ViewDoc('doc', '<cword>')<CR>
+	endif
 endif
 " - function
 " call ViewDoc('new', '<cword>')		auto-detect context/syntax and file type


### PR DESCRIPTION
Hi

I added the option to put the word which is being looked up in the Vim search register so that when one hints `n` in the documentation buffer the looked up word is searched.

Introduced the variable _g:viewdoc_copy_to_search_reg_ for enabling this
feature.

BTW this is a really nice plugin. I use it all the time. :+1: 
