### PR TITLE
Fix broken keyword in Python ftplugin

### DIFF
--- a/ftplugin/pydoc_viewdoc.vim
+++ b/ftplugin/pydoc_viewdoc.vim
@@ -3,9 +3,7 @@ if exists('b:did_ftplugin_viewdoc')
 endif
 let b:did_ftplugin_viewdoc = 1
 
-
 setlocal iskeyword+=.
-
 
 let b:undo_ftplugin = exists('b:undo_ftplugin') ? b:undo_ftplugin . '|' : ''
 let b:undo_ftplugin .= 'setlocal iskeyword<'


### PR DESCRIPTION
Defining a keyword is unecessary.
