### PR TITLE
Make ViewDocInfo behave identical to info command

### DIFF
--- a/doc/viewdoc.txt
+++ b/doc/viewdoc.txt
@@ -303,37 +303,33 @@ Added by bashhelp handler:~
 Added by info handler:~
 
 :info[!] 				        *:info*
-:info[!] {file}
+:info[!] {topic}
 :info[!] ({file}){node}
-:info[!] {file} {node}
+:info[!] {menu-item} ...
 	Abbrev for |:ViewDocInfo|.
 	To disable use |g:no_viewdoc_abbrev|.
 
 :ViewDocInfo[!] 				*:ViewDocInfo*
-:ViewDocInfo[!] {file}
+:ViewDocInfo[!] {topic}
 :ViewDocInfo[!] ({file}){node}
-:ViewDocInfo[!] {file} {node}
+:ViewDocInfo[!] {menu-item} ...
 	Show GNU info documentation.
 	* with no parameters it will load info directory (dir)Top
-	* with one parameter it will load a named node (if parameter is in
-	  (file)node format) or top node of named manual
-	* with two or more parameters it will load specified node, 1st
-	  parameter is used as manual name, the rest are used as node name
+	* with one or more parameters, it behaves identically to GNU Info.
 
 	Example invocations are: >
 	    :ViewDocInfo
-	    :ViewDocInfo gawk
-	    :ViewDocInfo (gawk)Functions
-	    :ViewDocInfo gawk Functions
-	    :ViewDocInfo gawk Getting Started
+	    :ViewDocInfo ls
+	    :ViewDocInfo (coreutils)
+	    :ViewDocInfo (coreutils)ls\ invocation
+	    :ViewDocInfo Bash Bash\ Features Aliases
 <
-	Works in same way as |:ViewDoc| with {filetype}=info, plus:
-	* use (dir)Top as default without params
-	* support {file} as separate first param
-	* support {file} {node} as separate params
-	* provide auto-complete for {file} and {node}: >
-	    :info ga<Tab>	" auto-complete {file}
-	    :info gawk Ex<Tab>	" auto-complete {node} for gawk
+	Features auto-complete for {topic} and ({file}){node} separately: >
+	    :ViewDocInfo <Tab>		" auto-complete {topic}
+	    :ViewDocInfo Fil<Tab>	" auto-complete {topic}
+	    :ViewDocInfo (co<Tab>	" auto-complete ({file}){node}
+<
+	Note that completion is implemented only for the first argument.
 
 ==============================================================================
 SETTINGS					*viewdoc-settings*

--- a/plugin/viewdoc_info.vim
+++ b/plugin/viewdoc_info.vim
@@ -25,11 +25,7 @@ endif
 " - command
 " Can be called:
 "  - with no parameters, will load info directory
-"  - with one parameter, will load named node (if in (file)node format) or top
-"    page for named manual
-"  - with two or more parameters, will use first parameter as manual name
-"    (parentheses are optional) and all other parameters as node name
-" eg. :ViewDocInfo gawk Getting Started   will load "(gawk)Getting Started"
+"  - with one or more parameters, should behave identically to GNU Info.
 command -bar -bang -nargs=* -complete=custom,s:CompleteInfo ViewDocInfo
 	\ call ViewDoc('<bang>'=='' ? 'new' : 'doc', s:ParamsToNode(<f-args>), 'infocmd')
 " - abbrev
@@ -53,8 +49,17 @@ function s:ViewDoc_info(topic, filetype, synid, ctx)
 		" patterns below contain some empty groups \(\), this is intentional,
 		" because we want to have link parts in the same groups, no matte whet
 		" format the link has
-		if synIDattr(a:synid, 'name') == 'infoLinkDir' ||
-		\  synIDattr(a:synid, 'name') == 'infoDirTarget'
+		if synIDattr(a:synid, 'name') == 'infoNavLink'
+			" links in the top navigation line
+			let nav_match = matchlist(getline('.')[:col('.')], '^File:.*\(Prev\|Next\|Up\): \(.\)')
+			let nav = nav_match[1]
+			if nav_match[2] == '('
+				let pattern = '^File: .*' . nav . ': \([^,]*\)\(\)\(\)'
+			else
+				let pattern = '^File: .*' . nav . ': \(\)\([^,]*\)\(\)'
+			endif
+		elseif synIDattr(a:synid, 'name') == 'infoLinkDir' ||
+		\      synIDattr(a:synid, 'name') == 'infoDirTarget'
 			" links in main directory
 			let pattern = '^\* [^:]\+: \(([^)]\+)\)\([^.]*\)\.\(\)'
 		elseif synIDattr(a:synid, 'name') == 'infoLinkMenu'
@@ -71,7 +76,12 @@ function s:ViewDoc_info(topic, filetype, synid, ctx)
 			endif
 		elseif synIDattr(a:synid, 'name') == 'infoLinkNote'
 			" "note" links inside pages, these can span multiple lines
-			let current_line = current_line.' '.getline(line('.') + 1)
+			if match(current_line, '\*[Nn]ote') < 0
+				let prev_line = getline(line('.') - 1)
+				let current_line = prev_line[match(prev_line, '.*\zs\*[Nn]ote'):].' '.current_line
+			else
+				let current_line = current_line.' '.getline(line('.') + 1)
+			endif
 			let pattern = '\*[Nn]ote [^:.]\+: \([^.,]\+\)\%([,.]\|$\)'
 			let link = matchlist(current_line, pattern)
 			if link == []
@@ -85,8 +95,11 @@ function s:ViewDoc_info(topic, filetype, synid, ctx)
 			return nothing
 		endif
 		let link = matchlist(current_line, pattern)
-		let file = link[1] !='' ? link[1] : same_file
-		let node = link[2] !='' ? link[2] : 'Top'
+		let file = same_file
+		if link[1] != ''
+			let file = s:FixNodeName(link[1])
+		endif
+		let node = link[2] != '' ? link[2] : 'Top'
 		let h.topic = file . node
 		if link[3] != ''
 			let h.line = str2nr(link[3])
@@ -123,7 +136,6 @@ function s:ViewDoc_info_search(topic, filetype, synid, ctx)
 	for idx in indices
 		execute 'silent $r !' . g:viewdoc_info_cmd . ' ' . shellescape(s:FixNodeName(idx), 1)
 	endfor
-	1
 	" search for a first matching index entry
 	if search('^\* ' . a:topic . '\W')
 		let current_line = getline('.')
@@ -155,7 +167,7 @@ endfunction
 " Handler for command line commands
 function s:ViewDoc_info_cmd(topic, ...)
 	let h = { 'ft': 'info',
-        	\ 'topic': s:FixNodeName(a:topic) }
+		\ 'topic': s:FixNodeName(a:topic) }
 	let h.cmd = printf('%s %s -o-', g:viewdoc_info_cmd, shellescape(h.topic, 1))
 	return h
 endfunction
@@ -168,26 +180,22 @@ endfunction
 function s:ParamsToNode(...)
 	if a:0 == 0
 		return '(dir)Top'
-	elseif a:0 == 1
-		if a:1 =~ '^(.\+)'
-			return a:1
-		else
-			return printf('(%s)Top', a:1)
-		endif
 	else
-		if a:1 =~ '^(.\+)'
-			return join(a:000, ' ')
-		else
-			return printf('(%s)%s', a:1, join(a:000[1:], ' '))
+		let args = copy(a:000)
+		if args[0][0] == '('
+			let args[0] = s:FixNodeName(args[0])
 		endif
+		let sh_args =  join(map(args, 'shellescape(v:val)'), ' ')
+		return system(printf('%s %s -o- | head -n 2', g:viewdoc_info_cmd, sh_args) .
+		\             ' | sed -n ''s/^File: \(.*\)\.info,  Node: \([^,]*\),.*/(\1)\2/p''')
 	endif
 endfunction
 
 " Helper to fix (file) parts where manuals have versioned filenames
 function s:FixNodeName(node)
 	let file = substitute(a:node, '^(\([^)]\+\)).*', '\1', '')
-	if globpath('/usr/share/info', file.'.info*') == ''
-		let filenames = split(globpath('/usr/share/info', file.'-*.info*'))
+	if globpath(g:viewdoc_info_path, file.'.info*') == ''
+		let filenames = split(globpath(g:viewdoc_info_path, file.'-*.info*'))
 		let candidates = []
 		for fn in filenames
 			call add(candidates, substitute(fn, '^.*/\([^/]\+\)\.info.*$', '\1', ''))
@@ -204,16 +212,19 @@ endfunction
 " node names from manual, whose name is param1 when invoked for any other
 " parameter
 function s:CompleteInfo(ArgLead, CmdLine, CursorPos)
-	let parts = split(strpart(a:CmdLine, 0, a:CursorPos).'|')
-	if len(parts)>2
-		let heads = system(g:viewdoc_info_cmd . ' --subnodes ' .
-		\           shellescape(parts[1], 1) . " 2>/dev/null | grep '^File: .*,  Node:'")
-		return substitute(heads, 'File: [^\n]*,  Node: \([^,]*\),  [^\n]*', '\1', 'g')
-	else
-		return substitute(substitute(globpath(g:viewdoc_info_path, '*.info*'),
-		\                            '[^\n]*/\([^/]\+\).info[^\n]*', '\1', 'g'),
-		\                 '\([^\n]*\n\)\1*', '\1', 'g')
-  endif
+	let part = join(split(substitute(a:CmdLine[0:a:CursorPos], '\\', '', 'g'))[1:], ' ')
+	let base_cmd = g:viewdoc_info_cmd . " '(dir)Top' 2>/dev/null"
+	let keys_pipe = ' | sed -n ''s/\* \([^:]*\): (.*/\1/p'''
+	let ext_pipe = ' | sed -n ''s/\* [^:]*: \(([^.]*\)\..*/\1/p'' | sort | uniq'
+	if len(part) == 0
+		return escape(system(base_cmd . keys_pipe), ' ')
+	endif
+	let pipe = keys_pipe
+	if part[0] == '('
+		let pipe = ext_pipe
+	endif
+	let part = part . (len(a:ArgLead) == 0 ? ' ' : '')
+	return escape(system(base_cmd . pipe . " | sed -n " . shellescape("/^" . part . "/p")), ' ')
 endfunction
 
 

--- a/syntax/info.vim
+++ b/syntax/info.vim
@@ -12,6 +12,7 @@ elseif exists("b:current_syntax")
 endif
 
 syn case match
+syn match infoTopNav /^File: .*\.info,  Node: [^,]*,.*$/ contains=infoNavLink
 syn match infoMenuTitle  /^\* Menu:/hs=s+2,he=e-1
 syn match infoTitle  /^[A-Z][0-9A-Za-z `',/&]\{,43}\([a-z']\|[A-Z]\{2}\)$/
 syn match infoTitle  /^[-=*]\{,45}$/
@@ -20,6 +21,7 @@ syn match infoLinkMenu /^\* [^:]*::/hs=s+2
 syn match infoLinkDir /^\* [^:]*: ([^)]*)[^.]*\./hs=s+2,he=e-1 contains=infoDirTarget
 syn match infoLinkIndex /^\* [^:]*:\s*[^.]*\.[ \t\n]*(line\s\+[0-9]\+)$/hs=s+2 contains=infoIndexTarget,infoIndexLine
 syn region infoLinkNote start=/\*[Nn]ote/ end=/\(::\|[.,]\)/ contains=infoNoteNote
+syn match infoNavLink contained /\(Prev\|Next\|Up\): \zs[^,]*/
 syn match infoDirTarget contained /: ([^)]*)[^.]*\./hs=s+1,he=e-1
 syn match infoIndexTarget contained /:\s*.\+\./hs=s+1,he=e-1
 syn region infoIndexLine contained start=/(line/ end=/)$/
@@ -27,6 +29,7 @@ syn match infoNoteNote contained /\*[Nn]ote/hs=s+1
 
 hi def link infoMenuTitle Title
 hi def link infoTitle Comment
+hi def link infoNavLink Directory
 hi def link infoLinkMenu Directory
 hi def link infoLinkDir Directory
 hi def link infoLinkIndex Directory


### PR DESCRIPTION
- Fixes #35
- Support for arguments:
  - Major topic names (those given in `(dir)`)
  - Menu items: `{topic} {sub-topic} ...`
  - File-Node pair: `({file}){node}`
- Auto-completion for major topic names, and partially for file-node pairs
- Navigate using Prev, Next and Top links (second line)