### PR TITLE
viewdoc_help: bugfix with options

### DIFF
--- a/plugin/viewdoc_help.vim
+++ b/plugin/viewdoc_help.vim
@@ -31,7 +31,13 @@ function s:ViewDoc_help(topic, filetype, synid, ctx)
 		\ }
 	if a:ctx
 		if h.topic !~ "^'.*'$" && (synIDattr(a:synid,'name') =~# 'Option' || search('&\k*\%#','n'))
-			let h.topic = "'" . h.topic . "'"	" auto-detect: 'option'
+			" auto-detect: 'option'
+			let matched = matchstr(h.topic, "'\\k\\+'")
+			if len(matched)
+				let h.topic = matched
+			else
+				let h.topic = "'" . h.topic . "'"
+			endif
 		elseif synIDattr(a:synid,'name') =~ 'Command'
 			let h.topic = ':' . h.topic		" auto-detect: :command
 		endif


### PR DESCRIPTION
**Issue:** pressing enter on an option surrounded by quotes, having a special character nearby such as a comma or paranthesis, will result in wrong navigation.
**Fix:** Pattern match the topic WORD
**Reproduce**: Open help of `strwidth()`, Press enter over `'ambiwidth'` (a few lines below).