### PR TITLE
Allow limiting winwidth

### DIFF
--- a/doc/viewdoc.txt
+++ b/doc/viewdoc.txt
@@ -392,6 +392,12 @@ g:viewdoc_copy_to_search_reg	=0 (default)		*g:viewdoc_copy_to_search_reg*
 	search register which allows to easily search in the documentation for
 	occurrences of this word.
 
+g:viewdoc_winwidth_max		=0 (default)		*g:viewdoc_winwidth_max*
+        If set, limits the text width passed to doc formatters, so paragraphs
+        width can be limited to |g:viewdoc_winwidth_max| characters rather than
+        stretch across very wide windows.  Some documentation is pre-formatted,
+        and this will have no effect.
+
 Added by man handler:~
 
 g:viewdoc_man_cmd   ="man" (default)            *g:viewdoc_man_cmd*

--- a/plugin/viewdoc.vim
+++ b/plugin/viewdoc.vim
@@ -36,6 +36,9 @@ endif
 if !exists('g:viewdoc_copy_to_search_reg')
 	let g:viewdoc_copy_to_search_reg=0
 endif
+if !exists('g:viewdoc_winwidth_max')
+	let g:viewdoc_winwidth_max=0
+endif
 
 """ Interface
 " - command
@@ -101,7 +104,8 @@ function ViewDoc(target, topic, ...)
 	for h in hh
 		if exists('h.cmd')
 			call ViewDoc_SetShellToBash()
-			let h.cmd = substitute(h.cmd, '{{winwidth}}', winwidth('.'), 'g')
+			let winwidth = g:viewdoc_winwidth_max > 0 ? min([winwidth('.'), g:viewdoc_winwidth_max]) : winwidth('.')
+			let h.cmd = substitute(h.cmd, '{{winwidth}}', winwidth, 'g')
 			execute 'silent 0r ! ( ' . h.cmd . ' ) 2>/dev/null'
 			call ViewDoc_RestoreShell()
 			silent $d


### PR DESCRIPTION
Hi!  Thank you for viewdoc, it's been extremely handy for reading and writing documentation.

This PR adds an optional setting to limit `winwidth` in order to keep paragraphs more readable on wider windows.  For example, I've set mine to 100, which is no change in smaller windows and terminals, but keeps man and perldoc from becoming hard to read on very wide GUI windows.  This may also satisfy issue #43.