### PR TITLE
Correctly escape tags contained spaces

### DIFF
--- a/plugin/viewdoc.vim
+++ b/plugin/viewdoc.vim
@@ -132,7 +132,7 @@ function ViewDoc(target, topic, ...)
 
 	let b:topic = h.topic
 	if exists('h.tags')
-		execute 'setlocal tags^=' . h.tags
+        execute "setlocal tags^=" . substitute( h.tags, ' ', '\\ ', "g" )
 	endif
 	if exists('h.docft')
 		let b:docft = h.docft

--- a/plugin/viewdoc.vim
+++ b/plugin/viewdoc.vim
@@ -132,7 +132,7 @@ function ViewDoc(target, topic, ...)
 
 	let b:topic = h.topic
 	if exists('h.tags')
-		execute "setlocal tags^=" . substitute( h.tags, ' ', '\\ ', "g" )
+		execute 'setlocal tags^=' . h.tags
 	endif
 	if exists('h.docft')
 		let b:docft = h.docft

--- a/plugin/viewdoc.vim
+++ b/plugin/viewdoc.vim
@@ -132,7 +132,7 @@ function ViewDoc(target, topic, ...)
 
 	let b:topic = h.topic
 	if exists('h.tags')
-        execute "setlocal tags^=" . substitute( h.tags, ' ', '\\ ', "g" )
+		execute "setlocal tags^=" . substitute( h.tags, ' ', '\\ ', "g" )
 	endif
 	if exists('h.docft')
 		let b:docft = h.docft

--- a/plugin/viewdoc_help.vim
+++ b/plugin/viewdoc_help.vim
@@ -85,7 +85,7 @@ function s:ViewDoc_help_custom(topic, ft, ...)
 			let h.cmd	= printf('cat %s', shellescape(helpfile,1))
 			let h.line	= line('.')
 			let h.col	= col('.')
-			let h.tags	= tagsfile
+			let h.tags	= substitute( tagsfile, ' ', '\\ ', "g" )
 			break
 		endfor
 		setlocal bufhidden=delete

--- a/plugin/viewdoc_help.vim
+++ b/plugin/viewdoc_help.vim
@@ -51,6 +51,7 @@ function s:ViewDoc_help(topic, filetype, synid, ctx)
 		let h.line	= line('.')
 		let h.col	= col('.')
 		let h.tags	= substitute(helpfile, '/[^/]*$', '/tags', '')
+		let h.tags	= substitute( h.tags, ' ', '\\ ', "g" )
 		noautocmd tabclose
 		execute 'noautocmd tabnext ' . savetabnr
 	catch


### PR DESCRIPTION
Sometimes tags can contain spaces.
Currently your code does not escape them and this leads to the error.
This patch fixes this ptoblem.